### PR TITLE
Fixes installation on MacOS on Apple Sillicon

### DIFF
--- a/install_init.py
+++ b/install_init.py
@@ -106,6 +106,8 @@ def install_llama(system_info):
         if system_info['gpu']:
             cuda_version = system_info['cuda_version']
             custom_command = f"--force-reinstall --no-deps --index-url=https://jllllll.github.io/llama-cpp-python-cuBLAS-wheels/{avx}/{cuda_version}"
+        elif "arm64" in system_info['platform_tag']:
+            custom_command = None
         else:
             custom_command = f"{base_url}{lcpp_version}/llama_cpp_python-{lcpp_version}-{system_info['platform_tag']}.whl"
         install_package("llama-cpp-python", custom_command=custom_command)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ torchvision>=0.15.2
 einops>=0.7.0
 safetensors>=0.4.1
 pillow>=9.4.0
-py-cpuinfo==3.3.0
+py-cpuinfo==3.3.0; platform_machine == "x86_64"
+py-cpuinfo==9; platform_machine == "arm64"
 gitpython
 moviepy
 opencv-python


### PR DESCRIPTION
- Bumps py-cpuinfo to version 9
- Since there are no precompiled llama-cpp-python wheels available for MacOS on Apple Sillicon, this installs direclty from pypiy.org